### PR TITLE
Fix instantiation error when not passing modules

### DIFF
--- a/src/Sharder.js
+++ b/src/Sharder.js
@@ -57,7 +57,7 @@ class Sharder {
             throw new Error('instanceID not provided');
         }
 
-        this.config = modules.Configuration || new Configuration(instanceID, options);
+        this.config = this.modules.Configuration || new Configuration(instanceID, options);
     }
 
 


### PR DESCRIPTION
This PR aims to fix the failure of the `Sharder` class instantation when the (supposed to be optional) `modules` argument isn't passed